### PR TITLE
update react-docgen https://github.com/reactjs/react-docgen/releases/…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# WebStorm IDE settings
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-prop-table",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Parse react source file and generate html or markdown table",
   "main": "index.js",
   "scripts": {
@@ -41,6 +41,6 @@
     "humanize-proptype": "0.0.3",
     "lodash": "~3.10.1",
     "markdown-tableify": "0.0.4",
-    "react-docgen": "~2.4.0"
+    "react-docgen": "~2.14.0"
   }
 }


### PR DESCRIPTION
Hi, I create tiny MR contains update [react-docgen package](https://github.com/reactjs/react-docgen/releases/tag/v2.14.0) for support new [prop-types package](https://github.com/reactjs/prop-types) (in [React 15.5.0](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html) React.PropTypes moved  into a separate package).

But I do not fully understand how to correct the tests...